### PR TITLE
Re-initialize marshallers when a domain or config changes.

### DIFF
--- a/MarshallersGrailsPlugin.groovy
+++ b/MarshallersGrailsPlugin.groovy
@@ -47,6 +47,11 @@ class MarshallersGrailsPlugin {
 		XmlMarshallerArtefactHandler,
 		JsonMarshallerArtefactHandler
 	]
+
+    def watchedResources = [
+        'file:./grails-app/domain/*.groovy',
+        'file:./grails-app/conf/Config.groovy'
+    ]
     
     def author = "Predrag Knezevic"
     def authorEmail = "pedjak@gmail.com"
@@ -79,4 +84,8 @@ Further documentation can be found on the GitHub repo.
 		applicationContext.extendedConvertersConfigurationInitializer.initialize()
 		log.debug "Marshallers Plugin configured successfully"
 	}
+
+    def onChange = { event ->
+        event.ctx.extendedConvertersConfigurationInitializer.initialize()
+    }
 }


### PR DESCRIPTION
During development, it's not uncommon to be tweaking the custom marshallers
while the application is running.  With this update, any time a domain class or
the main configuration is changed, the plugin will re-initialize the
marshallers.
