### PR TITLE
If a property is Integer or Float and has value = 0 or 0.0f then this property isn't write to XML.

### DIFF
--- a/src/groovy/org/grails/plugins/marshallers/GenericDomainClassXMLMarshaller.groovy
+++ b/src/groovy/org/grails/plugins/marshallers/GenericDomainClassXMLMarshaller.groovy
@@ -109,7 +109,7 @@ class GenericDomainClassXMLMarshaller implements ObjectMarshaller<XML>,NameAware
 					serializers[property.name].call(val,xml)
 					xml.end()
 				}else{
-					if(val){
+					if(val != null){
 						if (log.debugEnabled) log.debug("Trying to write field as xml element: $property.name on $value")
 						writeElement(xml, property, beanWrapper,mc)
 					}


### PR DESCRIPTION
Properties containing 0 (Integer) or 0.0f (Float) aren't write to XML, however 0 or 0.0f can be a meaningful value in several domains. I've changed the test from "if (val)" to "if (val != null)", this way this properties are correctly rendered in XML.
